### PR TITLE
Proposed story tweaks for S1

### DIFF
--- a/scenarios/chapter1/01_The_Uprooting.cfg
+++ b/scenarios/chapter1/01_The_Uprooting.cfg
@@ -57,12 +57,12 @@ Chapter One" + </span>
             story=_ "Perhaps the elders sensed that changing times would require more flexible minds; these were the years when humans from the Green Isle were establishing themselves south of the Great River, and the known world was changing more rapidly than it had for a thousand years before."
         [/part]
         [part]
-            story=_ "Some changes were good. The elves, awakened as from a long dream, began to increase in population. But some were very bad, and the worst of those was the coming of the orcs, the wreckers, the tree-killers. The years of Kalenz and Landar long childhoods were a golden age, and the last time of untroubled peace."
+            story=_ "Some changes were good. The elves, awakened as from a long dream, began to increase in number. Yet others were most foul, and worst of those was the coming of the orcs, the wreckers, the tree-killers. The elves had never been a martial people and they were not prepared for the inevitable war with the orcs."
         [/part]
         [part]
-            story=_ "The elves had never been a martial people, and they were not prepared for the inevitable war with the orcs. The friends came of age in the very year that Erlornas of Wesmere fought the first orcish raiders. Within the next decade orcish raids greatly increased, and their shadow loomed ever greater over the elves.
+            story=_ "The years of Kalenz' and Landar's long childhoods were a golden age and the last time of untroubled peace. The friends came of age in the very year that Erlornas of Wesmere fought the first orcish raiders. Within the next decade orcish raids greatly increased and their shadow loomed ever greater over the elves.
 
-This is the story of Kalenz, Landar, and of the elves in the first days of the humans in Wesnoth."
+This is the story of Kalenz, Landar, and of the elves in the first days of a perilous new age."
             background="story/landscape-battlefield.webp"
         [/part]
     [/story]
@@ -287,12 +287,12 @@ This is the story of Kalenz, Landar, and of the elves in the first days of the h
 
         [message]
             id=Kalenz
-            message= _ "Orcs are pressing on us from all directions! To arms!"
+            message= _ "Orcs press us from all sides! To arms!"
         [/message]
 
         [message]
             id=Velon
-            message= _ "Hold, Kalenz, the Ka’lian Council has not declared war. Maybe we can reach an agreement with them!"
+            message= _ "Hold, Kalenz, they are too many. We must seek to reach some agreement with them!"
         [/message]
 
         [message]
@@ -302,32 +302,22 @@ This is the story of Kalenz, Landar, and of the elves in the first days of the h
 
         [message]
             id=Velon
-            message= _ "Lintanir's forces are barely strong enough to handle their dark hordes! We have no choice but to submit!"
+            message= _ "Until Elensiria learns of our plight, force of arms shalln't avail us! We have no choice but to submit!"
         [/message]
 
         [message]
             id=Kalenz
-            message= _ "Elves must never surrender to these evil beasts. If we can't defeat them on our own, we will call for help! I'm going to Wesmere, who's with me?"
+            message= _ "Elves must never surrender to these vile beasts. If we cannot defeat them on our own, we shall call for aid! I go to Elensiria, who is with me?"
         [/message]
 
         [message]
             id=Landar
-            message= _ "We are with you, Kalenz, but why Wesmere? It's so far away!"
+            message= _ "We are with you, Kalenz! Yet they have surrounded us, how shall we escape?"
         [/message]
 
         [message]
             id=Kalenz
-            message= _ "Not long ago, Lord Erlornas of Wesmere defeated an orc invasion of his forest. He knows how to defeat these creatures, and he will help us as no one else can."
-        [/message]
-
-        [message]
-            id=Landar
-            message= _ "But we are surrounded, how do we escape from the grove?"
-        [/message]
-
-        [message]
-            id=Kalenz
-            message= _ "We must storm one of the orcs’ outposts to break the encirclement before more enemies arrive!"
+            message= _ "We must storm one of the orcs’ outposts to break free from this encirclement before more arrive!"
         [/message]
 
         [message]
@@ -386,12 +376,12 @@ This is the story of Kalenz, Landar, and of the elves in the first days of the h
 
         [message]
             id=Graur-Tan
-            message= _ "You really believe we're taking captives? Ha-ha, die!"
+            message= _ "Hahaha, you really believed we take captives? Die!"
         [/message]
 
         [message]
             id=Velon
-            message= _ "Kalenz was right and I was wrong; good thing the elves followed him. Go, Kalenz, save them! I and the remaining elders will cover your retreat as best we may."
+            message= _ "Kalenz was right and I was wrong; 'tis lucky our youths followed him. Onwards, Kalenz, save them! I and the remaining elders will cover your retreat as best we may."
         [/message]
     [/event]
 
@@ -490,16 +480,6 @@ This is the story of Kalenz, Landar, and of the elves in the first days of the h
         [/message]
 
         [message]
-            id=Kalenz
-            message= _ "I will bring Wesmere's greatest swordsmen, and the orcs will pay dearly for invading our home."
-            [show_if]
-                [have_unit]
-                    id=Velon
-                [/have_unit]
-            [/show_if]
-        [/message]
-
-        [message]
             id=Landar
             message= _ "Velon taught us to be strong, but counseled weakness. Even so, he did not deserve such an ugly death. We shall return and avenge him!"
             [show_if]
@@ -514,7 +494,7 @@ This is the story of Kalenz, Landar, and of the elves in the first days of the h
         [message]
             canrecruit=yes
             race=orc
-            message= _ "You won’t get very far! After them!"
+            message= _ "You will not get far, pixies! After them!"
         [/message]
     [/event]
 
@@ -540,7 +520,7 @@ This is the story of Kalenz, Landar, and of the elves in the first days of the h
 
         [message]
             speaker=second_unit
-            message= _ "Take that, you orcish scum!"
+            message= _ "Too slow, beast!"
         [/message]
     [/event]
 


### PR DESCRIPTION
Among these tweaks is a change of the heroes' next destination from the Ka'lian in Wesmere to Elensiria, the capital of Lintanir, where they meet with Lord Uradredia:

> After Scenario 1, Kalenz and Landar go to Lord Uradredya. They tell him about the invasion and suggest asking Lord Erlornas for help, as he has defeated the orcs before. However, Uradredya is a proud lord. He believes that Lintanir is as good as Wesmere, and there is no need to ask Wesmere for help at the first sign of trouble. If Erlornas could defeat the orcs, then he can too. Lintanir is a large forest. Uradredya will decide to retreat into the forest. Far from their rear, the orcs will not be able to fight in the cold forest and will lose. Something like the tactics of the Russian army during Napoleon's invasion.

> However, Kalenz and Landar believe that this is a dangerous tactic. The orcs are destroying everything in their path. Retreat will cost the elves of Lintanir dearly. So they decide to go to Wesmere themselves for help.

This follow up scenario is to-be-done.