### PR TITLE
S7 less travel time for Landar's side

### DIFF
--- a/maps/asq.map
+++ b/maps/asq.map
@@ -17,9 +17,9 @@ Ww, Rr, Ds, Rr, Ds, Ww, Ww^Es, Ww^Es, Ww, Ww, Ww, Ww, Ww, Hh^Fp, Ww, Hh^Fp, Hh^F
 Ww, Ww, Ww, Ds, Ww, Ww, Ww, Ww, Ds, Ww, Mm, Ww, Ww, Ww, Ww, Wwr, Wwr, Hh, Hh, Hh^Vhh, Wwr, Ww, Ww, Ds, Gd, Re, Gll^Fp, Gd^Ve, Gll^Fp, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm
 Re, Ww, Ww, Ww, Ww, Ww, Ww, Ds, Mm, Mm, Mm, Mm, Mm, Ww, Ww, Wwr, Ww, Wwr, Ww, Hh, Ww, Ww, Ww, Ds, Re, Gd, Gll^Fp, Gll^Fp, Mm, Mm, Mm, Mm, Hh^Vhh, Mm, Gll^Fp, Mm, Mm
 Gg, Re, Re, Gd, Gd, Ww, Wwr, Gd, Mm, Mm, Mm, Mm, Hh, Gll^Fp, Gll^Fp, Ww, Ww, Ww, Wwr, Ww, Ww, Wwr, Mm, Wwr, Re, Gll^Fp, Gll^Fp, Gs^Fms, Hh, Mm, Mm, Mm, Hh, Hh, Gll^Fp, Mm, Mm
-Hh, Gg, Hh, Gd, Gd, Gd, Gd, Gd, Hh, Hh, Gll^Fp, Gll^Fp, Gll^Fp, Gg^Ve, Gll^Fmw, Gll^Fp, Wwr, Mm, Ds, Ds, Ds, Ww, Wwr, Wwr, Gll^Fp, Gll^Fp, Gs^Fms, Gs^Fms, Mm, Hh, Mm, Mm, Hh, Gll^Fp, Gll^Fp, Hh, Mm
-Hh, Hh, Hh, Hh, Hh, Gd^Vc, Hh, Hh, Mm, Hh, Gll^Fmw, Gll^Tf, Gll^Fmw, Gll^Fp, Wwr, Gll^Fp, Ww, Wwr, Hh^Fmw, Gd^Fp, Gd^Fp, Gd^Vc, Gd^Fp, Wwf, Gll^Fp, Gg^Fet, Gll^Fp, Mm, Mm, Mm, Hh, Hh, Mm, Mm, Mm, Gll^Fp, Mm
-Mm, Hh, Mm, Hh, Mm, Hh, Mm, Mm, Hh, Gll^Fp, Gll^Fp, Gll^Fp, Hh, Hh, Ww, Ww, Hh, Mm, Hh^Fmw, Gd^Fp, Hh^Fmw, Gd^Fp, Hh^Fmw, Wwf, Ww, Gs^Fms, Mm, Mm, Mm, Hh, Hh^Vhh, Hh, Mm, Mm, Mm, Mm, Mm
+Hh, Gg, Hh, Gd, Gll^Fp, Gd, Gd, Gd, Gll^Fp, Hh, Gll^Fp, Gll^Fp, Gll^Fp, Gg^Ve, Gll^Fmw, Gll^Fp, Wwr, Mm, Ds, Ds, Ds, Ww, Wwr, Wwr, Gll^Fp, Gll^Fp, Gs^Fms, Gs^Fms, Mm, Hh, Mm, Mm, Hh, Gll^Fp, Gll^Fp, Hh, Mm
+Hh, Hh, Hh, Hh, Hh, Gs^Vc, Hh, Gll^Fp, Mm, Gll^Fp, Gll^Fmw, Gll^Tf, Gll^Fmw, Gll^Fp, Wwr, Gll^Fp, Ww, Wwr, Hh^Fmw, Gd^Fp, Gd^Fp, Gd^Vc, Gd^Fp, Wwf, Gll^Fp, Gg^Fet, Gll^Fp, Mm, Mm, Mm, Hh, Hh, Mm, Mm, Mm, Gll^Fp, Mm
+Mm, Hh, Mm, Hh, Mm, Hh, Mm, Mm, Hh, Gll^Fp, Gll^Fp, Gll^Fp, Hh, Hh, Ww, Wwf, Wwf, Mm, Hh^Fmw, Gd^Fp, Hh^Fmw, Gd^Fp, Hh^Fmw, Wwf, Ww, Gs^Fms, Mm, Mm, Mm, Hh, Hh^Vhh, Hh, Mm, Mm, Mm, Mm, Mm
 Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Hh, Hh, Gll^Fp, Mm, Mm, Wwf, Mm, Wwr, Mm, Cte, Cte, Hh, Cte, Hh, Mm, Ww, Mm, Wwr, Wwr, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm
 Mm, Mm, Mm, Mm, Mm, Mm, Mm, Hh^Vhh, Mm, Mm, Mm, Mm, Hh, Ww, Mm, Mm, Mm, Cte, 5 Kte, Cte^Es, Cte, Mm, Mm, Wwr, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm
 Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Ww, Ww, Mm, Mm, Mm, Cte, Cte, Cte^Es, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Hh^Vhh, Mm, Mm, Gll^Fp, Gll^Fp, Gll^Fp, Mm, Mm, Mm


### PR DESCRIPTION
After defeating the southern trolls, it takes Landar's squad slightly too long with too little action to reach the final enemy castle. Changing a few terrain tiles past the southern troll camp reduces this a bit.