### PR TITLE
S3: Set Achievement after the message in the last breath events

### DIFF
--- a/scenarios/03_Hostile_Mountains.cfg
+++ b/scenarios/03_Hostile_Mountains.cfg
@@ -603,15 +603,15 @@
             side=1,2
         [/filter_second]
 
-        [set_achievement]
-            content_for=low 
-            id=low_s3_revenge
-        [/set_achievement]
-
         [message]
             speaker=second_unit 
             message=_ "For Velon!"
         [/message]
+
+        [set_achievement]
+            content_for=low 
+            id=low_s3_revenge
+        [/set_achievement]
     [/event]
 
 #define ENDSPEECH SPEAKER_NAME
@@ -668,17 +668,17 @@
         [filter_second]
             race=dwarf
         [/filter_second]
-
-        [set_achievement]
-            content_for=low 
-            id=low_s2_trolls
-        [/set_achievement]
         
         [message]
             id=Grugl
             # wmllint: local spelling Urgh
             message= _ "Urgh! Grugl tried to eat dwarves, but choked on their sharp nasty axes."
         [/message]
+
+        [set_achievement]
+            content_for=low 
+            id=low_s2_trolls
+        [/set_achievement]
 
         {ENDSPEECH "Kalenz"}
 
@@ -711,15 +711,15 @@
             race=elf
         [/filter_second]
 
-        [set_achievement]
-            content_for=low 
-            id=low_s2_trolls
-        [/set_achievement]
-
         [message]
             id=Grugl
             message= _ "Urgh! Grugl wanted tasty elf-meat, but choked on their nasty pointy spears!"
         [/message]
+
+        [set_achievement]
+            content_for=low 
+            id=low_s2_trolls
+        [/set_achievement]
 
         {ENDSPEECH second_unit}
 #undef ENDSPEECH


### PR DESCRIPTION
- The event sequence flows better when the achievement granted popup after the last breath message of the enemy leader.

- Current behavior is a sudden out of nowhere achievement pop up and then the message